### PR TITLE
Wrap divisions in calc()

### DIFF
--- a/src/stylesheets/active_material/generators/functions.scss
+++ b/src/stylesheets/active_material/generators/functions.scss
@@ -6,7 +6,7 @@
 /// @param {number} $amount - An integer value, such as 100
 /// @return {number} The amount of letter-spacing in ems.
 @function am-tracking($amount) {
-  @return ($amount / 1000) + 0em;
+  @return calc($amount / 1000) + 0em;
 }
 
 
@@ -15,7 +15,7 @@
 /// @param {number} $number - The numeric value to strip units from.
 /// @return {number} A unitless number value.
 @function am-strip-units($number) {
-  @return $number / ($number * 0 + 1);
+  @return calc($number / ($number * 0 + 1));
 }
 
 
@@ -31,7 +31,7 @@
 /// @param {number} $baseline [16] - The assumed base font size.
 /// @return {number} Scalable pixel value in rems.
 @function am-sp($value, $baseline:16) {
-  @return (am-strip-units($value) / $baseline) + rem;
+  @return calc(am-strip-units($value) / $baseline) + rem;
 }
 
 

--- a/src/stylesheets/active_material/prototypes/menu.scss
+++ b/src/stylesheets/active_material/prototypes/menu.scss
@@ -39,7 +39,7 @@ $am-menu-carat-size: 5px !default;
   border-color: am-color(primary) transparent transparent;
   content: "";
   height: 0;
-  margin-top: $am-menu-carat-size / -2;
+  margin-top: calc($am-menu-carat-size / -2);
   position: absolute;
   right: -15px;
   top: 50%;


### PR DESCRIPTION
Sass is making the breaking change that using a slash as a division will no longer be supported in the future [[1]](https://sass-lang.com/documentation/breaking-changes/slash-div/). This package currently uses a slash as a division operator in a few instances, which will break in Dart 2.0. This PR migrates those to be wrapped within `calc()`, which will ensure they will continue to work