### PR TITLE
Avoid using ruby 3.1 methods to keep gem compatible with older ruby versions

### DIFF
--- a/lib/active_material/font_loader.rb
+++ b/lib/active_material/font_loader.rb
@@ -3,10 +3,24 @@ module ActiveMaterial
     def build_active_admin_head
       within super do
         uri = URI.parse(ActiveMaterial::Rails::Engine.config.active_material.font_url)
-        link(rel: "preconnect", href: uri.origin)
-        link(rel: "preconnect", href: uri.origin, crossorigin: true)
+        origin = extract_origin(uri)
+
+        link(rel: "preconnect", href: origin)
+        link(rel: "preconnect", href: origin, crossorigin: true)
         link(rel: "stylesheet", href: uri.to_s)
       end
+    end
+
+    private
+
+    def extract_origin(uri)
+      origin = "#{uri.scheme}://#{uri.host}"
+      origin += ":#{uri.port}" if uri.port && !default_port?(uri)
+      origin
+    end
+
+    def default_port?(uri)
+      (uri.scheme == 'http' && uri.port == 80) || (uri.scheme == 'https' && uri.port == 443)
     end
   end
 end


### PR DESCRIPTION
`uri.origin` method has been introduced to `URI` since ruby 3.1, see [URI::HTTP ruby 3.1](https://ruby-doc.org/stdlib-3.1.1/libdoc/uri/rdoc/URI/HTTP.html) vs [URI::HTTP ruby 3.0](https://ruby-doc.org/stdlib-3.0.1/libdoc/uri/rdoc/URI/HTTP.html)
I would suggest to avoid using this method and replace it with a custom implementation to keep the gem compatible with older versions of ruby. Otherwise to set `required_ruby_version` in gemspec.