### PR TITLE
Resolve dartsass deprecation warnings

### DIFF
--- a/app/assets/stylesheets/active_material/components/dropdown.scss
+++ b/app/assets/stylesheets/active_material/components/dropdown.scss
@@ -27,7 +27,7 @@
   }
 
   li a {
-    @include am-menu-link;
     @include am-menu-item-open;
+    @include am-menu-link;
   }
 }

--- a/app/assets/stylesheets/active_material/components/header.scss
+++ b/app/assets/stylesheets/active_material/components/header.scss
@@ -11,9 +11,10 @@
 }
 
 .site_title {
-  @include am-toolbar-title;
-  @include am-color(text-light);
   text-shadow: 0 1px 2px rgba(#000, 0.15);
+
+  @include am-color(text-light);
+  @include am-toolbar-title;
 }
 
 #tabs {

--- a/app/assets/stylesheets/active_material/components/title_bar.scss
+++ b/app/assets/stylesheets/active_material/components/title_bar.scss
@@ -3,13 +3,14 @@
  */
 
 .title_bar {
-  @include am-toolbar-title;
-  @include am-fill(white);
   box-shadow: 0 1px 2px rgba(#000, 0.24);
   align-items: center;
   display: flex;
   position: relative;
   z-index: 1;
+
+  @include am-fill(white);
+  @include am-toolbar-title;
 }
 
 #titlebar_left {

--- a/app/assets/stylesheets/active_material/generators/functions.scss
+++ b/app/assets/stylesheets/active_material/generators/functions.scss
@@ -1,3 +1,6 @@
+@use "sass:color";
+@use "sass:map";
+
 /// Emulates letter tracking in Adobe Photoshop, which is used for
 /// adjusting the space between letters in text.
 ///
@@ -51,8 +54,8 @@
 /// @param {any} $key - The desired key in $am-colors.
 /// @return {color} A color value from $am-colors.
 @function am-color ($key) {
-  @if map-has-key($am-colors, $key) {
-    @return map-get($am-colors, $key);
+  @if map.has-key($am-colors, $key) {
+    @return map.get($am-colors, $key);
   }
 
   @error "Unknown color value '#{$key}'";
@@ -66,7 +69,7 @@
 /// @param {number} $amount - The degree of lightness.
 /// @return {color} A lightened color value from $am-colors.
 @function am-lighten ($color, $amount) {
-  @return lighten(am-color($color), $amount);
+  @return color.adjust(am-color($color), $lightness: $amount, $space: hsl);
 }
 
 
@@ -76,7 +79,7 @@
 /// @param {number} $amount - The degree of darkness.
 /// @return {color} A darkened color value from $am-colors.
 @function am-darken ($color, $amount) {
-  @return darken(am-color($color), $amount);
+  @return color.adjust(am-color($color), $lightness: -$amount, $space: hsl);
 }
 
 /// Extracts a font family out of the $am-fonts map. Throws an error if that key is not defined.
@@ -84,8 +87,8 @@
 /// @param {any} $key - The desired key in $am-colors.
 /// @return {font} A font family from $am-colors.
 @function am-font-family ($key) {
-  @if map-has-key($am-fonts, $key) {
-    @return map-get($am-fonts, $key);
+  @if map.has-key($am-fonts, $key) {
+    @return map.get($am-fonts, $key);
   }
 
   @error "Unknown font value '#{$key}'";

--- a/app/assets/stylesheets/active_material/prototypes/table.scss
+++ b/app/assets/stylesheets/active_material/prototypes/table.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 /**
  * Tables
  */
@@ -69,7 +71,7 @@ $am-table-border-color: am-color(divider);
   td,
   th {
     box-shadow: 0 -1px 0 rgba(#000, 0.05);
-    border-bottom: 1px solid darken($am-table-border-color, 5%);
+    border-bottom: 1px solid color.adjust($am-table-border-color, $lightness: -5%, $space: hsl);
   }
 }
 
@@ -79,7 +81,7 @@ $am-table-border-color: am-color(divider);
   td,
   th {
     box-shadow: 0 -1px 0 rgba(#000, 0.15);
-    border-bottom: 1px solid darken($am-table-border-color, 15%);
+    border-bottom: 1px solid color.adjust($am-table-border-color, $lightness: -15%, $space: hsl);
   }
 }
 

--- a/app/assets/stylesheets/active_material/values/colors.scss
+++ b/app/assets/stylesheets/active_material/values/colors.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 ////
 /// @group colors
 ////
@@ -83,8 +85,8 @@ $theme-error: $am-theme-error !default;
 
 $am-colors: (
   accent               : $am-theme-accent,
-  accent-active        : lighten($am-theme-accent, 2%),
-  accent-hover         : lighten($am-theme-accent, 5%),
+  accent-active        : color.adjust($am-theme-accent, $lightness: 2%, $space: hsl),
+  accent-hover         : color.adjust($am-theme-accent, $lightness: 5%, $space: hsl),
   backdrop             : $am-theme-backdrop,
   black                : black,
   divider              : $am-theme-divider,


### PR DESCRIPTION
This resolves the following deprecation warnings:

```
css             | Deprecation Warning: Sass's behavior for declarations that appear after nested
css             | rules will be changing to match the behavior specified by CSS in an upcoming
css             | version. To keep the existing behavior, move the declaration above the nested
css             | rule. To opt into the new behavior, wrap the declaration in `& {}`.
css             |
css             | More info: https://sass-lang.com/d/mixed-decls
```

```
css             | Deprecation Warning: lighten() is deprecated. Suggestions:
css             |
css             | color.scale($color, $lightness: 19.6784565916%)
css             | color.adjust($color, $lightness: 12%)
```

```
css             | Deprecation Warning: darken() is deprecated. Suggestions:
css             |
css             | color.scale($color, $lightness: -100%)
css             | color.adjust($color, $lightness: -65%)
css             |
css             | More info: https://sass-lang.com/d/color-functions
```

```
css             | Deprecation Warning: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
css             | Use map.has-key instead.
css             |
css             | More info and automated migrator: https://sass-lang.com/d/import
```

And a few more similar ones.